### PR TITLE
Fix logo path to work on all routes

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -52,7 +52,7 @@ const Header: React.FC<HeaderProps> = ({
             <div className="flex-shrink-0 flex items-center">
               <Link to="/" className="flex items-center">
                 <img 
-                  src="runebond-isologo.svg" 
+                  src="/runebond-isologo.svg" 
                   alt="RUNE" 
                   className="h-12 w-12"
                 />


### PR DESCRIPTION
Logo was broken when accessing pages with a subdirectory path (e.g., https://runebond.com/nodes/). Changed logo path to absolute so it works on all routes.